### PR TITLE
Rename taido field to taito

### DIFF
--- a/cv/migrations/0002_rename_taido_to_taito.py
+++ b/cv/migrations/0002_rename_taido_to_taito.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cv", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="taidot",
+            old_name="taido",
+            new_name="taito",
+        ),
+    ]
+

--- a/cv/models.py
+++ b/cv/models.py
@@ -31,8 +31,8 @@ class Koulutus(models.Model):
         return f"{self.tutkinto} at {self.oppilaitos}"
 
 class Taidot(models.Model):
-    taido = models.CharField(max_length=100)
+    taito = models.CharField(max_length=100)
     taso = models.IntegerField(choices=[(i, f"{i}/5") for i in range(1, 6)])
-    
+
     def __str__(self):
-        return f"{self.taido} {self.taso}"
+        return f"{self.taito} {self.taso}"

--- a/cv/templates/cv/home.html
+++ b/cv/templates/cv/home.html
@@ -62,7 +62,7 @@
             {% for taito in taidot %}
             <div class="col-md-2">
                 <div class="skill-icon mx-auto">{{ taito.taso }}</div>
-                <div class="skill-label">{{ taito.taido }}</div>
+                <div class="skill-label">{{ taito.taito }}</div>
             </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
## Summary
- rename Taidot.taido field to taito and adjust __str__
- update skill display in home template
- add migration to rename field

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_688f3f4030f88322b66cf812db2c8060