### PR TITLE
Allow missing end dates

### DIFF
--- a/cv/migrations/0003_alter_koulutus_valmistumisvuosi_and_tyokokemus_loppupvm.py
+++ b/cv/migrations/0003_alter_koulutus_valmistumisvuosi_and_tyokokemus_loppupvm.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cv', '0002_rename_taido_to_taito'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='koulutus',
+            name='valmistumisvuosi',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='tyokokemus',
+            name='loppupvm',
+            field=models.DateField(blank=True, null=True),
+        ),
+    ]

--- a/cv/models.py
+++ b/cv/models.py
@@ -15,7 +15,7 @@ class Tyokokemus(models.Model):
     tehtava = models.CharField(max_length=100)
     kuvaus = models.TextField()
     alkupvm = models.DateField()
-    loppupvm = models.DateField()
+    loppupvm = models.DateField(blank=True, null=True)
     
     def __str__(self):
         return f"{self.tehtava} at {self.yritys}"
@@ -25,7 +25,7 @@ class Koulutus(models.Model):
     tutkinto = models.CharField(max_length=100)
     kuvaus = models.TextField()
     aloitusvuosi = models.DateField()
-    valmistumisvuosi = models.DateField()
+    valmistumisvuosi = models.DateField(blank=True, null=True)
     
     def __str__(self):
         return f"{self.tutkinto} at {self.oppilaitos}"

--- a/cv/templates/cv/home.html
+++ b/cv/templates/cv/home.html
@@ -30,7 +30,7 @@
     {% for tyok in tyokokemukset %}
       <div class="card-style mb-3">
         <h4>{{ tyok.tehtava }} – {{ tyok.yritys }}</h4>
-        <p class="text-muted">{{ tyok.alkupvm|date:"F Y" }} – {{ tyok.loppupvm|date:"F Y" }}</p>
+        <p class="text-muted">{{ tyok.alkupvm|date:"F Y" }} – {% if tyok.loppupvm %}{{ tyok.loppupvm|date:"F Y" }}{% else %}nykyhetki{% endif %}</p>
         <p>{{ tyok.kuvaus }}</p>
       </div>
     {% endfor %}
@@ -45,7 +45,7 @@
         {% for koulutus in koulutukset %}
         <div class="col-md-3 mx-2 card-style text-center">
             <h5>{{ koulutus.tutkinto }}</h5>
-            <p class="text-muted">{{ koulutus.oppilaitos }}<br>{{ koulutus.aloitusvuosi|date:"Y" }}–{{ koulutus.valmistumisvuosi|date:"Y" }}</p>
+            <p class="text-muted">{{ koulutus.oppilaitos }}<br>{{ koulutus.aloitusvuosi|date:"Y" }}–{% if koulutus.valmistumisvuosi %}{{ koulutus.valmistumisvuosi|date:"Y" }}{% else %}nykyhetki{% endif %}</p>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- Permit `loppupvm` and `valmistumisvuosi` to be optional and handle missing values on the homepage
- Add migration for nullable `loppupvm` and `valmistumisvuosi`
- Display "nykyhetki" when no end date is set for work or education entries

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688f408d063883229f71b55ef1e82463