### PR TITLE
Handle missing profile information in CV template

### DIFF
--- a/cv/templates/cv/home.html
+++ b/cv/templates/cv/home.html
@@ -13,13 +13,15 @@
 </section>
 
 <!-- Tietoa minusta -->
+{% if tietoa %}
 <section id="tietoa" class="mb-5">
     <div class="card-style text-center">
         <h2 class="mb-4">{{ tietoa.otsikko }}</h2>
         <img src="{{ tietoa.kuva.url }}" alt="Profiilikuva" class="img-fluid rounded my-3" width="200">
-        <p class="lead">{{tietoa.kuvaus}}</p>
+        <p class="lead">{{ tietoa.kuvaus }}</p>
     </div>
 </section>
+{% endif %}
 
 <!-- Työkokemus -->
 <section id="tyokokemus" class="mb-5">

--- a/cv/views.py
+++ b/cv/views.py
@@ -7,10 +7,14 @@ def home(request):
     tyokokemukset = Tyokokemus.objects.all().order_by('-alkupvm')
     koulutukset = Koulutus.objects.all().order_by('-aloitusvuosi')
     taidot = Taidot.objects.all().order_by('-taso')
-    return render(request, 'cv/home.html', {
-        'tietoa': tietoa,
+
+    context = {
         'tyokokemukset': tyokokemukset,
         'koulutukset': koulutukset,
         'taidot': taidot,
-    })
+    }
+    if tietoa is not None:
+        context['tietoa'] = tietoa
+
+    return render(request, 'cv/home.html', context)
 


### PR DESCRIPTION
## Summary
- Build context conditionally and render profile section only when `TietojaMinusta` exists

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f47a1cb28832296573fb1681a7559