### PR TITLE
Remove deprecated USE_L10N setting

### DIFF
--- a/jounicvsite/settings.py
+++ b/jounicvsite/settings.py
@@ -111,7 +111,6 @@ LANGUAGE_CODE = 'fi'         # ← muutetaan suomeksi
 TIME_ZONE = 'Europe/Helsinki'  # ← Suomen aikavyöhyke
 
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 


### PR DESCRIPTION
## Summary
- drop legacy `USE_L10N` from Django settings since it's obsolete in Django 5.x.

## Testing
- `python manage.py test`
- `python manage.py shell -c "from django.utils.formats import date_format; from django.utils import translation; from datetime import date; translation.activate('fi'); print(date_format(date(2024,5,17)))"`

------
https://chatgpt.com/codex/tasks/task_e_688f489c51948322ae782af2ec14d6f2