### PR TITLE
Use override_settings for test secret key

### DIFF
--- a/cv/tests.py
+++ b/cv/tests.py
@@ -1,16 +1,14 @@
 from datetime import date
 import tempfile
 
-from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from .models import Koulutus, Taidot, TietojaMinusta, Tyokokemus
 
-settings.SECRET_KEY = "test-secret-key"
 
-
+@override_settings(SECRET_KEY="test-secret-key")
 class ModelStringRepresentationTests(TestCase):
     """Ensure __str__ methods return expected strings."""
 
@@ -49,7 +47,7 @@ GIF_BYTES = (
 )
 
 
-@override_settings(MEDIA_ROOT=tempfile.gettempdir())
+@override_settings(MEDIA_ROOT=tempfile.gettempdir(), SECRET_KEY="test-secret-key")
 class HomeViewTests(TestCase):
     """Verify context and response of the home view."""
 


### PR DESCRIPTION
## Summary
- remove global SECRET_KEY assignment in tests
- use `@override_settings` to inject `SECRET_KEY` for test classes

## Testing
- `SECRET_KEY='dummy' python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f499e8b94832280790cd6b68b9ffb