### PR TITLE
Refine muted text style for experience and education

### DIFF
--- a/cv/static/cv/styles.css
+++ b/cv/static/cv/styles.css
@@ -98,3 +98,8 @@ footer a:hover {
 .bg-light .lead {
   color: #dddddd; /* Selkeämmin luettava vaalea teksti */
 }
+
+/* Custom muted text for dark background sections */
+.text-muted-light {
+  color: #ccc !important;
+}

--- a/cv/templates/cv/home.html
+++ b/cv/templates/cv/home.html
@@ -32,7 +32,7 @@
     {% for tyok in tyokokemukset %}
       <div class="card-style mb-3">
         <h4>{{ tyok.tehtava }} – {{ tyok.yritys }}</h4>
-        <p class="text-muted">{{ tyok.alkupvm|date:"F Y" }} – {% if tyok.loppupvm %}{{ tyok.loppupvm|date:"F Y" }}{% else %}nykyhetki{% endif %}</p>
+        <p class="text-muted-light">{{ tyok.alkupvm|date:"F Y" }} – {% if tyok.loppupvm %}{{ tyok.loppupvm|date:"F Y" }}{% else %}nykyhetki{% endif %}</p>
         <p>{{ tyok.kuvaus }}</p>
       </div>
     {% endfor %}
@@ -47,7 +47,7 @@
         {% for koulutus in koulutukset %}
         <div class="col-md-3 mx-2 card-style text-center">
             <h5>{{ koulutus.tutkinto }}</h5>
-            <p class="text-muted">{{ koulutus.oppilaitos }}<br>{{ koulutus.aloitusvuosi|date:"Y" }}–{% if koulutus.valmistumisvuosi %}{{ koulutus.valmistumisvuosi|date:"Y" }}{% else %}nykyhetki{% endif %}</p>
+            <p class="text-muted-light">{{ koulutus.oppilaitos }}<br>{{ koulutus.aloitusvuosi|date:"Y" }}–{% if koulutus.valmistumisvuosi %}{{ koulutus.valmistumisvuosi|date:"Y" }}{% else %}nykyhetki{% endif %}</p>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- replace Bootstrap's muted text with custom `text-muted-light` for work and education entries
- define `text-muted-light` class in stylesheet for better contrast on dark background

## Testing
- `python manage.py test` *(fails: The SECRET_KEY setting must not be empty.)*
- `python manage.py collectstatic --noinput` *(fails: You're using the staticfiles app without having set the STATIC_ROOT setting to a filesystem path.)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d3035d48322a2b5e6587b87761f